### PR TITLE
Fixed two problem

### DIFF
--- a/epub-translator.py
+++ b/epub-translator.py
@@ -331,7 +331,7 @@ class TranslatorEngine():
             for file in files:
                 ziph.write(os.path.join(root, file),
                            os.path.relpath(os.path.join(root, file),
-                                           os.path.join(path, '..')))
+                                           os.path.join(path, self.file_name + '_translated' + '\..')))
 
     def start(self, file_path):
         self.get_epub_file_info(file_path)

--- a/epub-translator.py
+++ b/epub-translator.py
@@ -225,9 +225,10 @@ class TranslatorEngine():
             for ele in epub_eles:
                 if isinstance(ele, element.NavigableString) and str(ele).strip() not in ['', 'html']:
                     nextpos += 1
-                    content = self.replace_translation_dict(
-                        translated_text[nextpos])
-                    ele.replace_with(element.NavigableString(content))
+                    if nextpos < len(translated_text):
+                        content = self.replace_translation_dict(
+                            translated_text[nextpos])
+                        ele.replace_with(element.NavigableString(content))
 
             with open(html_file, "w", encoding="utf-8") as w:
                 w.write(str(soup))

--- a/google_trans_new.py
+++ b/google_trans_new.py
@@ -343,7 +343,8 @@ class google_translator:
                             translate_text = ""
                             for sentence in sentences:
                                 sentence = sentence[0]
-                                translate_text += sentence.strip() + ' '
+                                if isinstance(sentence, str):
+                                    translate_text += sentence.strip() + ' '
                             translate_text = translate_text
                             if pronounce == False:
                                 return translate_text


### PR DESCRIPTION
Exception occurs while translating some files:
File "..\google_trans_new.py", line 346, in translate
    translate_text += sentence.strip() + ' '
AttributeError: 'NoneType' object has no attribute 'strip'
added variable type check

When archiving translated files into a workbook, an incorrect directory structure was created. Fixed this issue.